### PR TITLE
Modify cbench cource code to add -P parameter for packet-in rate configuration

### DIFF
--- a/cbench/cbench.c
+++ b/cbench/cbench.c
@@ -17,15 +17,18 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
-
 #include <openflow/openflow.h>
 
 #include "myargs.h"
 #include "cbench.h"
 #include "fakeswitch.h"
 
-
-
+#ifdef USE_EPOLL
+#include <sys/epoll.h>
+#define MAX_EVENTS	16
+struct epoll_event events[MAX_EVENTS];
+int epollfd;
+#endif
 
 struct myargs my_options[] = {
     {"controller",  'c', "hostname of controller to connect to", MYARGS_STRING, {.string = "localhost"}},
@@ -35,6 +38,7 @@ struct myargs my_options[] = {
     {"mac-addresses", 'M', "unique source MAC addresses per switch", MYARGS_INTEGER, {.integer = 100000}},
     {"ms-per-test", 'm', "test length in ms", MYARGS_INTEGER, {.integer = 1000}},
     {"port",        'p', "controller port",  MYARGS_INTEGER, {.integer = OFP_TCP_PORT}},
+    {"packet-rate", 'P', "cbench packet sent rate", MYARGS_INTEGER, {.integer = 10000}},
     {"ranged-test", 'r', "test range of 1..$n switches", MYARGS_FLAG, {.flag = 0}},
     {"switches",    's', "fake $n switches", MYARGS_INTEGER, {.integer = 16}},
     {"throughput",  't', "test throughput instead of latency", MYARGS_NONE, {.none = 0}},
@@ -70,28 +74,49 @@ double run_test(int n_fakeswitches, struct fakeswitch * fakeswitches, int mstest
         timersub(&now, &then, &diff);
         if( (1000* diff.tv_sec  + (float)diff.tv_usec/1000)> total_wait)
             break;
-        for(i = 0; i< n_fakeswitches; i++)
+
+        #ifdef USE_EPOLL
+        for(i = 0; i < MAX_EVENTS; i++) {
+            events[i].events = EPOLLIN | EPOLLOUT;
+        }
+        
+        int nfds = epoll_wait(epollfd, events, MAX_EVENTS, -1);
+
+
+        for(i = 0; i < nfds; i++) {
+            fakeswitch_handle_io(events[i].data.ptr, &(events[i].events));
+        }
+        #else
+        for(i = 0; i < n_fakeswitches; i++) 
             fakeswitch_set_pollfd(&fakeswitches[i], &pollfds[i]);
+        
+        poll(pollfds, n_fakeswitches, 1000);
 
-        poll(pollfds, n_fakeswitches, 1000);      // block until something is ready or 100ms passes
-
-        for(i = 0; i< n_fakeswitches; i++)
+        for(i = 0; i < n_fakeswitches; i++) 
             fakeswitch_handle_io(&fakeswitches[i], &pollfds[i]);
+        #endif
     }
     tNow = now.tv_sec;
     tmNow = localtime(&tNow);
     printf("%02d:%02d:%02d.%03d %-3d switches: flows/sec:  ", tmNow->tm_hour, tmNow->tm_min, tmNow->tm_sec, (int)(now.tv_usec/1000), n_fakeswitches);
     usleep(100000); // sleep for 100 ms, to let packets queue
+
+    int send_count = 0;
+
     for( i = 0 ; i < n_fakeswitches; i++)
     {
         count = fakeswitch_get_count(&fakeswitches[i]);
         printf("%d  ", count);
         sum += count;
+	send_count += fakeswitch_get_send_count(&fakeswitches[i]);
     }
     passed = 1000 * diff.tv_sec + (double)diff.tv_usec/1000;   
     passed -= delay;        // don't count the time we intentionally delayed
-    sum /= passed;  // is now per ms
-    printf(" total = %lf per ms \n", sum);
+    //sum /= passed;  // is now per ms
+    sum /= 1000;
+    printf(" total = %lf per ms, total packet sent: %d \n", sum, send_count);
+    total_send_count[test_number_indicator] = send_count;
+    test_number_indicator++;
     free(pollfds);
     return sum;
 }
@@ -99,78 +124,104 @@ double run_test(int n_fakeswitches, struct fakeswitch * fakeswitches, int mstest
 /********************************************************************************/
 
 int timeout_connect(int fd, const char * hostname, int port, int mstimeout) {
-    int ret = 0;
-    int flags;
-    fd_set fds;
-    struct timeval tv;
-    struct addrinfo *res=NULL;
-    struct addrinfo hints;
-    char sport[BUFLEN];
-    int err;
+	int ret = 0;
+	int flags;
+	fd_set fds;
+	struct timeval tv;
+	struct addrinfo *res=NULL;
+	struct addrinfo hints;
+	char sport[BUFLEN];
+	int err;
 
-    hints.ai_flags          = 0;
-    hints.ai_family         = AF_INET;
-    hints.ai_socktype       = SOCK_STREAM;
-    hints.ai_protocol       = IPPROTO_TCP;
-    hints.ai_addrlen        = 0;
-    hints.ai_addr           = NULL;
-    hints.ai_canonname      = NULL;
-    hints.ai_next           = NULL;
+	hints.ai_flags          = 0;
+	hints.ai_family         = AF_INET;
+	hints.ai_socktype       = SOCK_STREAM;
+	hints.ai_protocol       = IPPROTO_TCP;
+	hints.ai_addrlen        = 0;
+	hints.ai_addr           = NULL;
+	hints.ai_canonname      = NULL;
+	hints.ai_next           = NULL;
 
-    snprintf(sport,BUFLEN,"%d",port);
+	snprintf(sport,BUFLEN,"%d",port);
 
-    err = getaddrinfo(hostname,sport,&hints,&res);
-    if(err|| (res==NULL))
-    {
-        if(res)
-            freeaddrinfo(res);
-        return -1;
-    }
-    
+	err = getaddrinfo(hostname,sport,&hints,&res);
+	if(err|| (res==NULL))
+	{
+		if(res)
+			freeaddrinfo(res);
+		return -1;
+	}
+	
 
 
-    // set non blocking
-    if((flags = fcntl(fd, F_GETFL)) < 0) {
-        fprintf(stderr, "timeout_connect: unable to get socket flags\n");
-        freeaddrinfo(res);
-        return -1;
-    }
-    if(fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-        fprintf(stderr, "timeout_connect: unable to put the socket in non-blocking mode\n");
-        freeaddrinfo(res);
-        return -1;
-    }
+	// set non blocking
+	if((flags = fcntl(fd, F_GETFL)) < 0) {
+		fprintf(stderr, "timeout_connect: unable to get socket flags\n");
+		freeaddrinfo(res);
+		return -1;
+	}
+	if(fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+		fprintf(stderr, "timeout_connect: unable to put the socket in non-blocking mode\n");
+		freeaddrinfo(res);
+		return -1;
+	}
+	
+    #ifdef USE_EPOLL
+    struct epoll_event ev;
+    int epollfd = epoll_create(1);
+    ev.events = EPOLLIN | EPOLLOUT | EPOLLERR;
+	ev.data.fd = fd;
+	if(epoll_ctl(epollfd, EPOLL_CTL_ADD, fd, &ev) == -1) {
+	    printf("Cannot use epoll to create connection\n");
+	    return -1;
+	}
+    #else
     FD_ZERO(&fds);
     FD_SET(fd, &fds);
+    #endif
 
-    if(mstimeout >= 0) 
-    {
-        tv.tv_sec = mstimeout / 1000;
-        tv.tv_usec = (mstimeout % 1000) * 1000;
+	if(mstimeout >= 0) 
+	{
+	    tv.tv_sec = mstimeout / 1000;
+	    tv.tv_usec = (mstimeout % 1000) * 1000;
 
-        errno = 0;
+	    errno = 0;
 
-        if(connect(fd, res->ai_addr, res->ai_addrlen) < 0) 
-        {
-            if((errno != EWOULDBLOCK) && (errno != EINPROGRESS))
-            {
-                fprintf(stderr, "timeout_connect: error connecting: %d\n", errno);
-                freeaddrinfo(res);
-                return -1;
-            }
+	    if(connect(fd, res->ai_addr, res->ai_addrlen) < 0) 
+	    {
+		    if((errno != EWOULDBLOCK) && (errno != EINPROGRESS))
+		    {
+			    fprintf(stderr, "timeout_connect: error connecting: %d\n", errno);
+			    freeaddrinfo(res);
+			    return -1;
+		    }
         }
-        ret = select(fd+1, NULL, &fds, NULL, &tv);
-    }
+        #ifdef USE_EPOLL
+	    int nfds = epoll_wait(epollfd, &ev, 1, mstimeout);
+        #else
+        ret = select(fd + 1, NULL, &fds, NULL, &tv);
+        #endif
+	}
     freeaddrinfo(res);
 
+    #ifdef USE_EPOLL
+    close(epollfd);
+	
+    if(ev.events & EPOLLERR) {
+	    return -1;
+    } else {
+	    return 0;
+	}
+    #else
     if(ret != 1) 
     {
-        if(ret == 0)
-            return -1;
-        else
-            return ret;
+            if(ret == 0)
+                return -1;
+            else
+                return ret;
     }
     return 0;
+    #endif
 }
 
 /********************************************************************************/
@@ -256,6 +307,7 @@ int main(int argc, char * argv[])
     int     connect_group_size = myargs_get_default_integer(my_options, "connect-group-size");
     int     learn_dst_macs = myargs_get_default_flag(my_options, "learn-dst-macs");
     int     dpid_offset = myargs_get_default_integer(my_options, "dpid-offset");
+    global_packet_send_num  = myargs_get_default_integer(my_options, "packet-rate");
     int     mode = MODE_LATENCY;
     int     i,j;
 
@@ -304,6 +356,9 @@ int main(int argc, char * argv[])
                 break;
             case 's': 
                 n_fakeswitches = atoi(optarg);
+		// shock add for throughput sending rate control
+		global_switch_num = n_fakeswitches;
+		printf("global switch num: %d\n", global_switch_num);
                 break;
             case 't': 
                 mode = MODE_THROUGHPUT;
@@ -326,40 +381,43 @@ int main(int argc, char * argv[])
             case 'o':
                 dpid_offset = atoi(optarg);
                 break;
+	    case 'P':
+		global_packet_send_num = atoi(optarg);
+		break;
             default: 
                 myargs_usage(my_options, PROG_TITLE, "help message", NULL, 1);
         }
     }
 
-    if(warmup+cooldown >=  tests_per_loop) {
-        fprintf(stderr, "Error warmup(%d) + cooldown(%d) >= number of tests (%d)\n", warmup, cooldown, tests_per_loop);
-        exit(1);
-    }
+	if(warmup+cooldown >=  tests_per_loop) {
+		fprintf(stderr, "Error warmup(%d) + cooldown(%d) >= number of tests (%d)\n", warmup, cooldown, tests_per_loop);
+		exit(1);
+	}
 
     fprintf(stderr, "cbench: controller benchmarking tool\n"
-        "   running in mode %s\n"
-        "   connecting to controller at %s:%d \n"
-        "   faking%s %d switches offset %d :: %d tests each; %d ms per test\n"
-        "   with %d unique source MACs per switch\n"
-        "   %s destination mac addresses before the test\n"
-        "   starting test with %d ms delay after features_reply\n"
-        "   ignoring first %d \"warmup\" and last %d \"cooldown\" loops\n"
-        "   connection delay of %dms per %d switch(es)\n"
-        "   debugging info is %s\n",
-        mode == MODE_THROUGHPUT? "'throughput'": "'latency'",
-        controller_hostname,
-        controller_port,
-        should_test_range ? " from 1 to": "",
-        n_fakeswitches,
-        dpid_offset,
-        tests_per_loop,
-        mstestlen,
-        total_mac_addresses,
-        learn_dst_macs ? "learning" : "NOT learning",
-        delay,
-        warmup,cooldown,
-        connect_delay,connect_group_size,
-        debug == 1 ? "on" : "off");
+                "   running in mode %s\n"
+                "   connecting to controller at %s:%d \n"
+                "   faking%s %d switches offset %d :: %d tests each; %d ms per test\n"
+                "   with %d unique source MACs per switch\n"
+                "   %s destination mac addresses before the test\n"
+                "   starting test with %d ms delay after features_reply\n"
+                "   ignoring first %d \"warmup\" and last %d \"cooldown\" loops\n"
+                "   connection delay of %dms per %d switch(es)\n"
+                "   debugging info is %s\n",
+                mode == MODE_THROUGHPUT? "'throughput'": "'latency'",
+                controller_hostname,
+                controller_port,
+                should_test_range ? " from 1 to": "",
+                n_fakeswitches,
+                dpid_offset,
+                tests_per_loop,
+                mstestlen,
+                total_mac_addresses,
+                learn_dst_macs ? "learning" : "NOT learning",
+                delay,
+                warmup,cooldown,
+                connect_delay,connect_group_size,
+                debug == 1 ? "on" : "off");
     /* done parsing args */
     fakeswitches = malloc(n_fakeswitches * sizeof(struct fakeswitch));
     assert(fakeswitches);
@@ -369,6 +427,24 @@ int main(int argc, char * argv[])
     double  max = 0.0;
     double  v;
     results = malloc(tests_per_loop * sizeof(double));
+
+    total_send_count = malloc(tests_per_loop * sizeof(int *));
+    test_number_indicator = 0;
+
+    #ifdef USE_EPOLL
+    struct epoll_event ev;
+    epollfd = epoll_create(4096);
+    if(epollfd == -1) {
+    	fprintf(stderr, "Cannot create epollfd.\n");
+	    exit(1);
+    }
+    #endif
+
+    // [itri shock] add for ip prefix
+    for (i = 0; i < n_fakeswitches; i++)
+        fakeswitches[i].ip_index = i;
+    // [itri shock] add end
+
 
     for( i = 0; i < n_fakeswitches; i++)
     {
@@ -388,31 +464,53 @@ int main(int argc, char * argv[])
         if(debug)
             fprintf(stderr,"Initializing switch %d ... ", i+1);
         fflush(stderr);
+        #ifdef USE_EPOLL
         fakeswitch_init(&fakeswitches[i],dpid_offset+i,sock,BUFLEN, debug, delay, mode, total_mac_addresses, learn_dst_macs);
+        #else
+        fakeswitch_init(&fakeswitches[i], 0, sock, 65536, debug, delay, mode, total_mac_addresses, learn_dst_macs);
+        #endif
+
         if(debug)
             fprintf(stderr," :: done.\n");
         fflush(stderr);
+    
+        #ifdef USE_EPOLL
+	    ev.events = EPOLLIN | EPOLLOUT;
+	    ev.data.fd = sock;
+	    ev.data.ptr = &fakeswitches[i];
+
+	    if(epoll_ctl(epollfd, EPOLL_CTL_ADD, sock, &ev) == -1) {
+	    	fprintf(stderr, "Cannot add sock to epoll\n");
+	    	exit(1);
+    	}
+        #endif
+
         if(count_bits(i+1) == 0)  // only test for 1,2,4,8,16 switches
             continue;
         if(!should_test_range && ((i+1) != n_fakeswitches)) // only if testing range or this is last
             continue;
+
+	int sum_send_count = 0;
+
         for( j = 0; j < tests_per_loop; j ++) {
             if ( j > 0 )
                 delay = 0;      // only delay on the first run
             v = 1000.0 * run_test(i+1, fakeswitches, mstestlen, delay);
             results[j] = v;
-            if(j<warmup || j >= tests_per_loop-cooldown) 
-                continue;
+			if(j<warmup || j >= tests_per_loop-cooldown) 
+				continue;
             sum += v;
+	    sum_send_count += total_send_count[j];
             if (v > max)
               max = v;
             if (v < min)
               min = v;
         }
 
-        int counted_tests = (tests_per_loop - warmup - cooldown);
+	int counted_tests = (tests_per_loop - warmup - cooldown);
         // compute std dev
         double avg = sum / counted_tests;
+
         sum = 0.0;
         for (j = warmup; j < tests_per_loop-cooldown; ++j) {
           sum += pow(results[j] - avg, 2);
@@ -422,9 +520,21 @@ int main(int argc, char * argv[])
 
         printf("RESULT: %d switches %d tests "
             "min/max/avg/stdev = %.2lf/%.2lf/%.2lf/%.2lf responses/s\n",
-            i+1,
-            counted_tests,
-            min, max, avg, std_dev);
+                i+1,
+                counted_tests,
+                min, max, avg, std_dev);
+
+        long int total_packet_sent = 0;
+        printf("packet send_count: ");
+        for (j = 0; j < n_fakeswitches; j++) {
+            printf("%d ", fakeswitches[j].send_count);
+        }
+        printf("\n");
+
+	for (j = 0; j < tests_per_loop; j++)
+	    total_packet_sent += total_send_count[j];
+
+        printf("total packet sent: %ld, total packet sent rate: %d packets/sec\n", total_packet_sent, sum_send_count / (counted_tests * mstestlen / 1000));
     }
 
     return 0;

--- a/cbench/cbench.h
+++ b/cbench/cbench.h
@@ -5,4 +5,11 @@
 #define BUFLEN 65536
 #endif
 
+#ifdef __linux__
+#define USE_EPOLL
+#endif
+
+int *total_send_count;
+int test_number_indicator;
+
 #endif

--- a/cbench/fakeswitch.h
+++ b/cbench/fakeswitch.h
@@ -39,14 +39,26 @@ struct fakeswitch
     int current_mac_address;
     int learn_dstmac;
     int current_buffer_id;
+
+    // shock add for throughput sending rate control
+    int throughput_once_send_left;
+    struct timeval stamp;
+
+    int send_count;
+
+    // shock add for ip prefix index
+    int ip_index;
+    int ip_num;
 };
+
+int global_switch_num;
+int global_packet_send_num;
 
 /*** Initialize an already allocated fakeswitch
  * Fill in all of the parameters, 
  *  exchange OFP_HELLO, block waiting on features_request
  *  and send features reply
  * @param fs        Pointer to a fakeswitch
- * @param dpid      DPID
  * @param sock      A non-blocking socket already connected to 
  *                          the controller (will be non-blocking on return)
  * @param bufsize   The initial in and out buffer size
@@ -55,7 +67,6 @@ struct fakeswitch
  *                                 to use for packet ins from this switch
  */
 void fakeswitch_init(struct fakeswitch *fs, int dpid, int sock, int bufsize, int debug, int delay, enum test_mode mode, int total_mac_addresses, int learn_dstmac);
-
 
 /*** Set the desired flags for poll()
  * @param fs    Pointer to initalized fakeswitch
@@ -71,14 +82,13 @@ void fakeswitch_set_pollfd(struct fakeswitch *fs, struct pollfd *pfd);
  *      if it's a flow_mod, then incremenet count
  *      else ignore it
  * @param fs    Pointer to initalized fakeswitch
- * @param pfd   Pointer to an allocated poll structure
+ * @param pfd   Pointer to an allocated poll structure or the number of events as int
  */
-void fakeswitch_handle_io(struct fakeswitch *fs, const struct pollfd *pfd);
-
+void fakeswitch_handle_io(struct fakeswitch *fs, void* pfd_events);
 /**** Get and reset count 
  * @param fs    Pointer to initialized fakeswitch
  * @return      Number of flow_mod responses since last call
  */
 int fakeswitch_get_count(struct fakeswitch *fs);
-
+int fakeswitch_get_send_count(struct fakeswitch *fs);
 #endif

--- a/cbench/myargs.c
+++ b/cbench/myargs.c
@@ -93,8 +93,12 @@ myargs_to_short(struct myargs options[])
     {
         len+= snprintf(&shortargs[len], max-len, "%c", 
                 options[i].shortname);
-        if(options[i].type != MYARGS_NONE && options[i].type != MYARGS_FLAG)
-            len+= snprintf(&shortargs[len], max-len, ":");
+        if(options[i].type != MYARGS_NONE) {
+            if(options[i].type == MYARGS_FLAG)
+                len+= snprintf(&shortargs[len], max-len, "::");
+            else
+                len+= snprintf(&shortargs[len], max-len, ":");
+        }
     }
     shortargs[len]=0;
     return shortargs;


### PR DESCRIPTION
## Modification
- Add -P parameter in cbench.c and use epoll.
- Add new varibles in fakeswitch.h and new actions in fakeswitch.c.
## Installation:

```
cd oflops/cbench
make
```

or you want to use cbench any where:

```
cd oflops/
make
sudo make install
```
## Use Case:

cbench -t -P <packet-in rate you want.(per switch. per second.)>
ex: cbench -t -P 10000 ( 10000 packet-in/s per switch)

**-P parameter can't use without -t** 
